### PR TITLE
Fixed case of header file so can find it on Linux

### DIFF
--- a/Inflow/inflowparameterwidget.ui
+++ b/Inflow/inflowparameterwidget.ui
@@ -1092,7 +1092,7 @@
   <customwidget>
    <class>SimCenterAppWidget</class>
    <extends>QWidget</extends>
-   <header>simcenterappwidget.h</header>
+   <header>SimCenterAppWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
This pull request fixes a bug when compiling on Linux--header files need to be specified to match case used in file names